### PR TITLE
Add Spectre mitigation compiler option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,7 @@ if (COVERAGE)
     set(CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_EXE_LINKER_FLAGS_DEBUG} -g -fprofile-arcs -ftest-coverage --coverage")
 endif (COVERAGE)
 
+add_compile_options(/Qspectre) # add Spectre mitigation compiler option. (https://docs.microsoft.com/en-us/cpp/build/reference/qspectre?view=vs-2017)
 
 # We want to generate configuration.h from the template and make it so that it is accessible using the same
 # path during both library build and installed header use, without littering the source dir.


### PR DESCRIPTION
# PR: Short description of change

## Description

Add Spectre mitigation compiler option to resolve BinSkim errors on Win32-OpenSSH build.

## Checklist

- [ ] I have read followed [CONTRIBUTING.md](https://github.com/PJK/libcbor/blob/master/CONTRIBUTING.md)
	- [ ] I have added tests
	- [ ] I have updated the documentation
	- [ ] I have updated the CHANGELOG
- [ ] Are there any breaking changes? If so, are they documented?
- [ ] Does this PR introduce any platform specific code? If so, is this captured in the description?
- [ ] Security: Does this PR potentially affect security? If so, is this captured in the description?
- [ ] Performance: Does this PR potentially affect performance? If so, is this captured in the description?
